### PR TITLE
Correct include reference

### DIFF
--- a/docs/Reference/GVBMR95_Parameter_File_Syntax_trace_extr.md
+++ b/docs/Reference/GVBMR95_Parameter_File_Syntax_trace_extr.md
@@ -6,4 +6,4 @@ The [TRACE](./GVBMR95_Parameter_File_Syntax_extr.md#trace) parameter activates t
 Parameters to filter tracing are defined here in EXTRTPRM.  
 Trace data is written to DD EXTRTRAC.
 
-{% include_relative includes/GVBMR95_Parameter_File_syntax_trace.md %}
+{% include_relative includes/GVBMR95_Parameter_File_Syntax_trace.md %}

--- a/docs/Reference/GVBMR95_Parameter_File_Syntax_trace_refr.md
+++ b/docs/Reference/GVBMR95_Parameter_File_Syntax_trace_refr.md
@@ -6,4 +6,4 @@ The [TRACE](./GVBMR95_Parameter_File_Syntax_refr.md#trace) parameter activates t
 Parameters to filter tracing are defined here in REFRTPRM.  
 Trace data is written to DD REFRTRAC.
 
-{% include_relative includes/GVBMR95_Parameter_File_syntax_trace.md %}
+{% include_relative includes/GVBMR95_Parameter_File_Syntax_trace.md %}


### PR DESCRIPTION
The latest updates are not updating in the live doc, because an include reference is incorrect.